### PR TITLE
fix: dedup label value for existing nodes

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -256,6 +256,12 @@ func watchNodes(clientset *kubernetes.Clientset, m *model) *v1.NodeList {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				node := obj.(*v1.Node)
+				// only add for new one
+				for _, n := range m.nodes.Items {
+					if n.Name == node.Name {
+						return // if not, early return
+					}
+				}
 				m.nodes.Items = append(m.nodes.Items, *node)
 				m.updateTotalLabelKeys()
 			},


### PR DESCRIPTION
- after ede48a9 it happened
- add event handler always adds a node even if it exists
- fix - if node exists do not add it